### PR TITLE
Add hooks for onCall and onComplete

### DIFF
--- a/src/specs/telemetry.spec.js
+++ b/src/specs/telemetry.spec.js
@@ -1,9 +1,27 @@
 const { call } = require('../index')
 const { handlers, functions, cmds } = require('./effects')
-const { basicMultistep, badHandler } = functions
+const { basicMultistep, badHandler, basic } = functions
 const { sleep } = require('./test-util')
 
-test('telemetry', async () => {
+test('telemetry - onCommandCall', async () => {
+  let telemetry
+  const onCommandCall = t => {
+    telemetry = t
+  }
+  const config = { onCommandCall, name: 'telemetry' }
+  await call(config, handlers, basicMultistep, 'foo')
+  expect(telemetry.length).toEqual(2)
+  telemetry.forEach((t, i) => {
+    const message = 'foo' + (i + 1)
+    expect(t.args).toEqual([message])
+    expect(t.command).toEqual(cmds.echo(message))
+    expect(t.index).toEqual(0)
+    expect(t.step).toEqual(i)
+    expect(t.config).toEqual(config)
+  })
+})
+
+test('telemetry - onCommandComplete', async () => {
   let telemetry = []
   const onCommandComplete = t => {
     telemetry.push(t)
@@ -26,12 +44,12 @@ test('telemetry', async () => {
   })
 })
 
-test('telemetry on error', async () => {
+test('telemetry on error - onCommandComplete', async () => {
   let telemetry
   const onCommandComplete = t => {
     telemetry = t
   }
-  const config = { onCommandComplete, name: 'telemetry' }
+  const config = { onCommandComplete }
   const now = Date.now()
   const message = 'oops'
   try {
@@ -47,4 +65,24 @@ test('telemetry on error', async () => {
   expect(telemetry.step).toEqual(0)
   expect(telemetry.result.message).toEqual('oops')
   expect(telemetry.config).toEqual(config)
+})
+
+test('onCall', async () => {
+  let called
+  const onCall = t => {
+    called = t
+  }
+  const config = { onCall }
+  await call(config, handlers, basicMultistep, 'foo', 'bar', 'baz')
+  expect(called.args).toEqual(['foo', 'bar', 'baz'])
+})
+
+test('onComplete', async () => {
+  let complete
+  const onComplete = t => {
+    complete = t
+  }
+  const config = { onComplete, name: 'telemetry' }
+  await call(config, handlers, basic, 'foo')
+  expect(complete.result).toEqual('foo')
 })


### PR DESCRIPTION
This is an idea for https://github.com/orourkedd/effects-as-data/issues/12.

It's entirely possible to do the same thing by wrapping the `call` function per project, so I'm open to that as well if there aren't any additional use cases for these event handlers, but I figured I'd throw it on here to see if anyone thinks the hooks would be useful.