### PR TITLE
Fix false positives on errors with different messages.

### DIFF
--- a/mocha.opts
+++ b/mocha.opts
@@ -1,0 +1,6 @@
+--reporter spec
+--compilers js:babel-register
+--require babel-polyfill
+--ui tdd
+
+src/specs/test.spec.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "effects-as-data",
-  "version": "2.9.0",
+  "version": "2.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -849,6 +849,12 @@
           "dev": true
         }
       }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
     },
     "bser": {
       "version": "2.0.0",
@@ -2426,6 +2432,18 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -3177,6 +3195,12 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -3278,6 +3302,74 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -3366,6 +3458,65 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "diff": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effects-as-data",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "A micro abstraction layer for Javascript that makes writing, testing, and monitoring side-effects easy.",
   "main": "src/index.js",
   "repository": {
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "jest",
-    "test-mocha": "mocha src/**/*.spec.js --recursive --compilers js:babel-register --require babel-polyfill",
+    "test:mocha": "mocha --opts mocha.opts",
     "transpile": "babel src --out-dir es5 --source-maps",
     "deploy": "npm run transpile && npm test && npm publish; rm -rf es5",
     "perf": "node src/perf/fs"
@@ -23,7 +23,8 @@
     "babel-cli": "^6.24.1",
     "babel-jest": "^20.0.0",
     "babel-preset-es2015": "^6.24.1",
-    "jest-cli": "^20.0.0"
+    "jest-cli": "^20.0.0",
+    "mocha": "^3.5.0"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/src/specs/test-util.js
+++ b/src/specs/test-util.js
@@ -1,3 +1,5 @@
+const assert = require("assert")
+
 function errorToJson(e) {
   const props = Object.getOwnPropertyNames(e).concat('name')
   return props.reduce((p, c) => {
@@ -35,7 +37,30 @@ function sleep(ms) {
   })
 }
 
+function deepEqual(actual, expected) {
+  const a = normalizeError(actual)
+  const e = normalizeError(expected)
+  if (usingJest()) expect(a).toEqual(e)
+  else assert.deepEqual(a, e)
+}
+
+function normalizeError(v) {
+  const isError = v instanceof Error
+  if (!isError) return v
+  const props = Object.getOwnPropertyNames(v).concat("name")
+  return props.reduce((p, c) => {
+    if (c === "stack") return p
+    p[c] = v[c]
+    return p
+  }, {})
+}
+
+function usingJest() {
+  return typeof expect !== "undefined" && expect.extend && expect.anything
+}
+
 module.exports = {
   expectError,
-  sleep
+  sleep,
+  deepEqual
 }

--- a/src/specs/test.spec.js
+++ b/src/specs/test.spec.js
@@ -12,7 +12,7 @@ const {
   badHandler
 } = functions
 const { testFn, testFnV2, args } = require("../test")
-const { deepEqual } = require("../util")
+const { deepEqual } = require("./test-util")
 
 function* singleLine(id) {
   const s1 = yield cmds.httpGet(`http://example.com/api/v1/users/${id}`)

--- a/src/test.js
+++ b/src/test.js
@@ -1,6 +1,7 @@
 const assert = require("assert")
 const curry = require("lodash/curry")
 const chunk = require("lodash/chunk")
+const { deepEqual } = require("./util")
 
 const testRunner = (fn, expected, index = 0, previousOutput = null) => {
   checkForExpectedTypeMismatches(expected)
@@ -103,15 +104,6 @@ const testFnV2 = (fn, spec) => {
   }
 }
 
-function deepEqual(actual, expected) {
-  //  a little bit of jest support
-  if (typeof expect !== "undefined" && expect.extend && expect.anything) {
-    expect(actual).toEqual(expected)
-  } else {
-    assert.deepEqual(actual, expected)
-  }
-}
-
 // Semantic test builder
 const args = (...fnArgs) => {
   const t = [[fnArgs]]
@@ -165,5 +157,6 @@ module.exports = {
   testFn: curry(testFn, 2),
   testFnV2: curry(testFnV2, 2),
   alt,
-  args
+  args,
+  deepEqual
 }

--- a/src/test.js
+++ b/src/test.js
@@ -1,7 +1,7 @@
 const assert = require("assert")
 const curry = require("lodash/curry")
 const chunk = require("lodash/chunk")
-const { deepEqual } = require("./util")
+const { deepEqual } = require("./specs/test-util")
 
 const testRunner = (fn, expected, index = 0, previousOutput = null) => {
   checkForExpectedTypeMismatches(expected)
@@ -157,6 +157,5 @@ module.exports = {
   testFn: curry(testFn, 2),
   testFnV2: curry(testFnV2, 2),
   alt,
-  args,
-  deepEqual
+  args
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,3 @@
-const assert = require("assert")
-
 function isGenerator(fn) {
   return fn && fn.constructor && fn.constructor.name === "GeneratorFunction"
 }
@@ -36,26 +34,10 @@ function uuid(
   return b
 }
 
-function deepEqual(actual, expected) {
-  // Error comparisons aren't consistent across assertion libraries
-  if (actual instanceof Error && expected instanceof Error) {
-    const actualError = { message: actual.message, name: actual.name }
-    const expectedError = { message: expected.message, name: expected.name }
-    assert.deepEqual(actualError, expectedError)
-  } 
-  //  a little bit of jest support
-  else if (typeof expect !== "undefined" && expect.extend && expect.anything) {
-    expect(actual).toEqual(expected)
-  } else {
-    assert.deepEqual(actual, expected)
-  }
-}
-
 module.exports = {
   isGenerator,
   toArray,
   toPromise,
   delay,
-  uuid,
-  deepEqual
+  uuid
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,5 @@
+const assert = require("assert")
+
 function isGenerator(fn) {
   return fn && fn.constructor && fn.constructor.name === "GeneratorFunction"
 }
@@ -34,10 +36,26 @@ function uuid(
   return b
 }
 
+function deepEqual(actual, expected) {
+  // Error comparisons aren't consistent across assertion libraries
+  if (actual instanceof Error && expected instanceof Error) {
+    const actualError = { message: actual.message, name: actual.name }
+    const expectedError = { message: expected.message, name: expected.name }
+    assert.deepEqual(actualError, expectedError)
+  } 
+  //  a little bit of jest support
+  else if (typeof expect !== "undefined" && expect.extend && expect.anything) {
+    expect(actual).toEqual(expected)
+  } else {
+    assert.deepEqual(actual, expected)
+  }
+}
+
 module.exports = {
   isGenerator,
   toArray,
   toPromise,
   delay,
-  uuid
+  uuid,
+  deepEqual
 }


### PR DESCRIPTION
This PR:
- Sets up mocha and refactors tests in `src/specs/test.spec.js` to run with either mocha or Jest. This was done to ensure that we can verify that our functional tests work properly with either framework. It could be part of the CI to run both sets of tests.
- Adds regression test and addresses the bug in node's `assert.deepEqual` where all Errors are considered equal. This is a known and accepted issue as described here https://github.com/nodejs/node/issues/3122

Concerns:
- The modified `deepEqual` check on Errors is naive, creating two "error" objects with a message and name property and comparing them. I'm concerned about browser compatibility with this. Each browser has different property names on Errors and we could run into problems if someone is testing this with jasmine or some other client side testing framework. We may consider creating a function to normalize error properties across the different browsers and node.